### PR TITLE
Getdata

### DIFF
--- a/hana_decode/Decoder.h
+++ b/hana_decode/Decoder.h
@@ -48,6 +48,14 @@ namespace Decoder {
   static const Int_t DETMAP_FILE      = 135;
   static const Int_t TRIGGER_FILE     = 136;
   static const Int_t SCALER_EVTYPE    = 140;
+
+ // Access processed data for multi-function modules
+  enum EModuleType { kSampleADC, kPulseIntegral, kPulseTime, 
+            kPulsePeak, kPulsePedestal };  
+
+
 }
+
+
 
 #endif

--- a/hana_decode/Fadc250Module.C
+++ b/hana_decode/Fadc250Module.C
@@ -77,6 +77,18 @@ namespace Decoder {
     SetMode(F250_SAMPLE);  // needs to be driven by cratemap ... later
   }
 
+  Bool_t Fadc250Module::IsMultiFunction() { 
+     return kTRUE; 
+  }
+
+  Bool_t Fadc250Module::HasCapability(Decoder::EModuleType type) { 
+    if (type == kSampleADC || type == kPulseIntegral || type == kPulseTime 
+        || type == kPulsePeak || type == kPulsePedestal) {
+      return kTRUE;
+    } else {
+      return kFALSE; 
+    }
+  }
 
   Bool_t Fadc250Module::IsSlot(UInt_t rdata) {
 #ifdef WITH_DEBUG
@@ -110,6 +122,40 @@ namespace Decoder {
       cout << "Fadc250Module:: ERROR: The set mode "<<f250_setmode;
       cout << "   is not consistent with the found mode "<<f250_foundmode<<endl;
     }
+  }
+
+  Int_t Fadc250Module::GetData(Decoder::EModuleType type, Int_t chan, Int_t hit) const {
+    if (type == kPulseIntegral) return GetPulseIntegralData(chan, hit);
+    if (type == kPulseTime) return GetPulseTimeData(chan, hit);
+    if (type == kPulsePeak) return GetPulsePeakData(chan, hit);
+    if (type == kPulsePedestal) return GetPulsePedestalData(chan, hit);
+    return -1;
+  }
+
+  // FIXME: when to call this from EvData ?   
+  Int_t Fadc250Module::GetData(Decoder::EModuleType type, Int_t chan, Int_t hit, Int_t sample) const {
+    if (type == kSampleADC) return GetPulseSampleData(chan, hit, sample);
+  }
+
+
+  Int_t Fadc250Module::GetPulseIntegralData(Int_t chan, Int_t hit) const { 
+      return 0; // awaiting Eric Poosier's version
+  }
+
+  Int_t Fadc250Module::GetPulseTimeData(Int_t chan, Int_t hit) const {
+      return 0; // awaiting Eric Poosier's version
+  }
+
+  Int_t Fadc250Module::GetPulsePeakData(Int_t chan, Int_t hit) const {
+      return 0; // awaiting Eric Poosier's version
+  }
+	
+  Int_t Fadc250Module::GetPulsePedestalData(Int_t chan, Int_t hit) const {
+      return 0; // awaiting Eric Poosier's version
+  }
+
+  Int_t Fadc250Module::GetPulseSampleData(Int_t chan, Int_t hit, Int_t isample) const {
+      return 0; // awaiting Eric Poosier's version
   }
 
   Int_t Fadc250Module::GetAdcData(Int_t chan, Int_t ievent) const {

--- a/hana_decode/Fadc250Module.h
+++ b/hana_decode/Fadc250Module.h
@@ -28,9 +28,21 @@ public:
    virtual Int_t GetNumEvents() const { return fNumEvents; };
    virtual Int_t GetNumSamples(Int_t chan) const;
    virtual Int_t GetData(Int_t chan, Int_t event, Int_t which) const;
+   virtual Int_t GetData(Decoder::EModuleType type, Int_t chan, Int_t hit) const;
+   virtual Int_t GetData(Decoder::EModuleType type, Int_t chan, Int_t hit, Int_t sample) const;
    virtual Int_t GetAdcData(Int_t chan, Int_t ievent) const;
    virtual Int_t GetTdcData(Int_t chan, Int_t ievent) const;
+// I know that Eric Poosier's version has these methods.  But that code is not yet available.
+// I put placeholders here for now.
+   virtual Int_t GetPulseIntegralData(Int_t chan, Int_t hit) const;
+   virtual Int_t GetPulseTimeData(Int_t chan, Int_t hit) const;
+   virtual Int_t GetPulsePeakData(Int_t chan, Int_t hit) const;
+   virtual Int_t GetPulsePedestalData(Int_t chan, Int_t hit) const;
+   virtual Int_t GetPulseSampleData(Int_t chan, Int_t hit, Int_t isample) const;
+
    virtual Int_t GetMode() const;
+   Bool_t IsMultiFunction();
+   Bool_t HasCapability(Decoder::EModuleType type);
 
    void SetMode(Int_t mode) {
      f250_setmode = mode;

--- a/hana_decode/Module.h
+++ b/hana_decode/Module.h
@@ -44,6 +44,8 @@ namespace Decoder {
     virtual Int_t GetData(Int_t) const { return 0; };
     virtual Int_t GetData(Int_t, Int_t) const { return 0; };
     virtual Int_t GetData(Int_t, Int_t, Int_t) const { return 0; };
+    virtual Int_t GetData(Decoder::EModuleType type, Int_t chan, Int_t hit) const { return 0; };
+    virtual Int_t GetData(Decoder::EModuleType type, Int_t chan, Int_t hit, Int_t sample) const {return 0;};
 
     virtual Int_t Decode(const UInt_t *p) = 0; // implement in derived class
     // Loads slot data
@@ -95,6 +97,9 @@ namespace Decoder {
     Module& operator=(const Module &rhs);
 
     virtual void DoPrint() const;
+
+    Bool_t IsMultiFunction() { return kFALSE; };
+    Bool_t HasCapability(Decoder::EModuleType type) { return kFALSE; };
 
   protected:
 

--- a/hana_decode/THaEvData.h
+++ b/hana_decode/THaEvData.h
@@ -9,6 +9,7 @@
 
 
 #include "Decoder.h"
+#include "Module.h"
 #include "TObject.h"
 #include "TString.h"
 #include "THaSlotData.h"
@@ -69,34 +70,34 @@ public:
   Int_t     GetNextChan(Int_t crate, Int_t slot, Int_t index) const;
   const char* DevType(Int_t crate, Int_t slot) const;
 
-  // Access processed data for multi-function modules
-  enum EInfoType { kADC, kTDC };  // TODO: should be in DetMap; TODO: add more types
-  Bool_t HasCapability( EModuleType type, Int_t crate, Int_t slot ) const
+  Bool_t HasCapability( Decoder::EModuleType type, Int_t crate, Int_t slot ) const
   {
-    // TODO: implement (needs to access CrateMap ...)
-    return true;
+    Decoder::Module* module = GetModule(crate, slot);
+    if (!module) { 
+      std::cout << "No module at crate "<<crate<<"   slot "<<slot<<std::endl;
+      return false;
+    }
+    return module->HasCapability(type);
   }
   Bool_t IsMultifunction( Int_t crate, Int_t slot ) const
   {
-    // TODO: implement (needs to access CrateMap ...)
-    return false;
+    Decoder::Module* module = GetModule(crate, slot);
+    if (!module) { 
+      std::cout << "No module at crate "<<crate<<"   slot "<<slot<<std::endl;
+      return false;
+    }
+    return module->IsMultiFunction();
   }
 
-  Int_t GetData( EModuleType type, Int_t crate, Int_t slot, Int_t chan, Int_t hit ) const
+  Int_t GetData( Decoder::EModuleType type, Int_t crate, Int_t slot, Int_t chan, Int_t hit ) const
   {
-    // TODO: real implementation
-    if( !HasCapability( type, crate, slot ) )
-      throw someException;
-    if( IsMultifunction( crate, slot ) ) {
-      switch( type ) {
-      case kADC:
-	return GetADC( crate, slot, chan, hit );
-      case kTDC:
-	return GetTDC( crate, slot, chan, hit );
-	//...
-      }
-    } else
+    Decoder::Module* module = GetModule(crate, slot);
+    if (!module) return false;
+    if (module->HasCapability( type )) {
+      return module->GetData(type, chan, hit);
+    } else {
       return GetData( crate, slot, chan, hit );
+    }
   }
   
   // Optional functionality that may be implemented by derived classes


### PR DESCRIPTION
Here are modifications to THaEvData to make a new "GetData" method which can obtain data from the Modules using Decoder::EModuleType as the first argument.  It's based on a Fork of Ole's getdata branch.  The module in a particular crate and slot will return the data if it has the capability for that EModuleType.  This was tested on FADC data using my version of the Fadc250Module class.  The test code tstfadc_main.C produces identical results whether one (1) gets the module and uses the Get methods of the module, or (2) uses the new THaEvData::GetData method.  This is a promising start, but I caution that it will need to be revisited once the new Fadc250Module class is submitted by Eric Poosier.   Also, I have not yet considered other modules like F1Tdc.